### PR TITLE
Fixed: Move verified label to records

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -28,7 +28,6 @@ de:
     url: URL
     using_muscat: Editor Hilfe
     validity: Gültigkeit
-    verified: Gesichert
     when_to_input_new_record: Wann soll einen neuen Eintrag erstellt werden (Musikdrucke)
     workflow: Workflow
     'yes': Ja
@@ -813,6 +812,7 @@ de:
     variant_ms_title: Weiterer diplomatischer Titel
     variant_source_title: Weiterer diplomatischer Titel
     variations: Variationen
+    verified: Gesichert
     vocalist: Sänger
     voice_instrument: Besetzung
     volume_year_page: Jahrgang, Seite

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -28,7 +28,6 @@ en:
     url: URL
     using_muscat: Using Muscat
     validity: Validity
-    verified: Verified
     when_to_input_new_record: When to input a new record (printed music)
     workflow: Workflow
     'yes': 'Yes'
@@ -813,6 +812,7 @@ en:
     variant_ms_title: Variant title on manuscript
     variant_source_title: Variant title on source
     variations: Variations
+    verified: Verified
     vocalist: Vocalist
     voice_instrument: Voice/instrument
     volume_year_page: Volume, year, page

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -28,7 +28,6 @@ es:
     url: URL
     using_muscat: Uso de Muscat
     validity: Validez
-    verified: Verificada
     when_to_input_new_record: Cuándo crear un nuevo registro (música impresa)
     workflow: Flujo de trabajo
     'yes': Sí
@@ -810,6 +809,7 @@ es:
     variant_ms_title: Variante de título en fuente
     variant_source_title: Variante de título en fuente
     variations: Variaciones
+    verified: Verificada
     vocalist: Cantante
     voice_instrument: Voz/instrumento
     volume_year_page: Volumen, año, página

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -29,7 +29,6 @@ fr:
     url: URL
     using_muscat: Aide de Muscat
     validity: Validité
-    verified: Vérifié
     when_to_input_new_record: Quand saisir une nouvelle notice (musique imprimée)
     workflow: Flux de travail
     'yes': Oui
@@ -814,6 +813,7 @@ fr:
     variant_ms_title: Variante du titre diplomatique
     variant_source_title: Variante du titre diplomatique
     variations: Variations
+    verified: Vérifié
     vocalist: Vocaliste
     voice_instrument: Voix/instrument
     volume_year_page: Volume, année, page

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -28,7 +28,6 @@ it:
     url: URL
     using_muscat: Guida a Muscat
     validity: Validità
-    verified: Verificata
     when_to_input_new_record: Quando inserire una nuova scheda (edizioni musicali
       a stampa)
     workflow: Workflow
@@ -814,6 +813,7 @@ it:
     variant_ms_title: Varianti del titolo diplomatico
     variant_source_title: Varianti del titolo diplomatico
     variations: Variazioni
+    verified: Verificata
     vocalist: Cantante
     voice_instrument: Voce/strumento
     volume_year_page: Volume, anno, pagina

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -28,7 +28,6 @@ pl:
     url: URL
     using_muscat: Korzystanie z Muscatu
     validity: Ważność
-    verified: Zweryfikowane
     when_to_input_new_record: Kiedy wprowadzić nowy rekord (dla druków muzycznych)
     workflow: Przepływ pracy
     'yes': Tak
@@ -813,6 +812,7 @@ pl:
     variant_ms_title: Alternatywny tytuł w rękopisie
     variant_source_title: Alternatywny tytuł w źródle
     variations: Wariacje
+    verified: Zweryfikowane
     vocalist: Wokalista
     voice_instrument: Głos/instrument
     volume_year_page: Wolumen, rok, strona

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -28,7 +28,6 @@ pt:
     url: ''
     using_muscat: Catalogando fontes
     validity: Validade
-    verified: Verificada
     when_to_input_new_record: Quando criar um novo registro (música impressa)
     workflow: ''
     'yes': Sim
@@ -810,6 +809,7 @@ pt:
     variant_ms_title: Variante de título na fonte
     variant_source_title: Título variante na fonte
     variations: ''
+    verified: Verificada
     vocalist: ''
     voice_instrument: Voz/instrumento
     volume_year_page: ''


### PR DESCRIPTION
The 'Verified' label is the only value for the record relationships qualifier to not be in the 'records' section; this moves it from the 'general' section to the 'records' section to make this more consistent.