### PR TITLE
Fixed: Remove hyphen from key

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -316,7 +316,7 @@ de:
     chronological_term: Datierungen
     city: Ort
     clef: Schlüssel
-    co-composer: Mitkomponist
+    co_composer: Mitkomponist
     coded_date: Datum und Ort eines Ereignisses (codiert)
     coded_instrumentation: Kodierte Besetzung
     collaborator: Mitverfasser

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -316,7 +316,7 @@ en:
     chronological_term: Chronological term
     city: City
     clef: Clef
-    co-composer: Co-composer
+    co_composer: Co-composer
     coded_date: Coded date
     coded_instrumentation: Coded instrumentation
     collaborator: Collaborator

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -316,7 +316,7 @@ es:
     chronological_term: Término cronológico
     city: Ciudad
     clef: Clave
-    co-composer: Co-compositor
+    co_composer: Co-compositor
     coded_date: Fecha codificada
     coded_instrumentation: Intrumentación codificada
     collaborator: Colaborador

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -317,7 +317,7 @@ fr:
     chronological_term: Datation
     city: Ville
     clef: Clé
-    co-composer: Compositeur secondaire
+    co_composer: Compositeur secondaire
     coded_date: Date et lieu d'un événement
     coded_instrumentation: Instrumentation codée
     collaborator: Collaborateur

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -317,7 +317,7 @@ it:
     chronological_term: Date
     city: Città
     clef: Chiave
-    co-composer: Compositore secondario
+    co_composer: Compositore secondario
     coded_date: Data e luogo di un evento
     coded_instrumentation: Codice della strumentazione
     collaborator: Collaboratore

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -316,7 +316,7 @@ pl:
     chronological_term: Datowanie
     city: Miejscowość
     clef: Klucz
-    co-composer: Współkompozytor
+    co_composer: Współkompozytor
     coded_date: Znormalizowana data
     coded_instrumentation: Standaryzowany zapis instrumentacji
     collaborator: Współtwórca

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -316,7 +316,7 @@ pt:
     chronological_term: ''
     city: ''
     clef: Clave
-    co-composer: Co-compositor [ctb]
+    co_composer: Co-compositor [ctb]
     coded_date: Data codificada
     coded_instrumentation: Instrumentação codificada
     collaborator: ''


### PR DESCRIPTION
A hyphen in a key is not always accepted as a correct value, since a hyphen can also be a list control character. This replaces the hyphen in 'co-composer' with an underscore.