### PR TITLE
New: Add Japanese, Fijian, and Friulian languages

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -57,10 +57,12 @@ en:
     english: English
     estonian: Estonian
     ethiopic: Ethiopic
+    fijian: Fijian
     finnish: Finnish
     french: French
     french_middle: French, Middle (ca. 1300-1600)
     french_old: French, Old (ca. 842-1300)
+    friulian: Friulian
     gallician: Galician
     german: German
     german_old_high: German, Old High (ca. 750-1050)
@@ -73,6 +75,7 @@ en:
     insari_sami: Inari Sami
     irish: Irish
     italian: Italian
+    japanese: Japanese
     korean: Korean
     latin: Latin
     latvian: Latvian


### PR DESCRIPTION
These are in records, but not available in the translations.