### PR TITLE
Update en.yml

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -875,7 +875,7 @@ en:
     uncategorized: Uncategorized
     unknown: Unknown
     unparsed_fingerprint: Unparsed fingerprint
-    variant_ms_title: Variant title on manuscript
+    variant_ms_title: Variant title on source
     variant_source_title: Variant title on source
     variations: Variations
     verified: Verified

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -708,7 +708,7 @@ en:
     performance: Performance
     performances: Performances
     performer: Performer
-    performer_note: Performer note
+    performer_note: Note on performance
     person: Person
     person_name: Person name
     personal_name: Personal name


### PR DESCRIPTION
On Sources, 246 is called `Variant title on source` but the subfield is labeled `Variant title on manuscript`. 

![image](https://github.com/rism-digital/translations/assets/18663291/f93e623c-7f25-4125-944d-c98358e38427)

Both need to say `source` because the same field is used in print and manuscript templates and it is not manuscript-specific. 

The correct label (with `source`) shows up on the full-record view and in RISM Online. (https://muscat.rism.info/admin/sources/240019, https://rism.online/sources/240019)

The German label does not have this discrepancy: `Weiterer diplomatischer Titel` for both.
![image](https://github.com/rism-digital/translations/assets/18663291/931f2c2f-72fe-498d-bf59-be1224e6b5e4)


