### PR TITLE
Editing EN terminology

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -390,7 +390,7 @@ en:
     country_activity: Country of activity
     country_code: Country code
     country_of_publication: Country of publication
-    county_province: County or province
+    county_province: County, province, state
     creation_production_note: Creation/production note
     cs_major: C♯ major
     cs_minor: C♯ minor
@@ -532,7 +532,7 @@ en:
     index_terms: Index terms
     information_found: Information found
     initial: Initial
-    initial_entry: Initial entry
+    initial_entry: Initial entry in A/I
     initials: Initials
     insertions: Insertions
     inserts: Inserts
@@ -750,7 +750,7 @@ en:
     production_personnel: Production personnel
     profession_or_function: Profession or function
     provenance: Provenance
-    provenance_notes: Provenance notes
+    provenance_notes: Provenance note
     pseudonym: Pseudonym
     public_note: Public note
     publisher: Publisher
@@ -881,7 +881,7 @@ en:
     typography: Typography
     uncategorized: Uncategorized
     unknown: Unknown
-    unparsed_fingerprint: Unparsed fingerprint
+    unparsed_fingerprint: Fingerprint
     variant_ms_title: Variant title on source
     variant_source_title: Variant title on source
     variations: Variations


### PR DESCRIPTION
Adjusting EN terminology:
- change `Provenance notes` to `Provenance note` (prefer singular)
- change `Initial entry` to `Initial entry in A/I` (point of clarification)
- change `County or province` to `County, province, state` (point of clarification)
- change `Unparsed fingerprint` to `Fingerprint` (we don't need to distinguished between parsed or not)