### PR TITLE
New key dates_of_publication

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -403,6 +403,7 @@ en:
     date_time_last_transaction: Date and time of last transaction
     date_type: Date type
     dates: Dates
+    dates_of_publication: Dates of publication
     dedicatee: Dedicatee
     department: Department
     depositor: Depositor


### PR DESCRIPTION
Adding new key `dates_of_publication` because we need this label in Secondary literature for the field 520 (in the spirit of 362; see https://github.com/rism-digital/muscat/issues/1490).
If approved, will add to the labels.