### PR TITLE
Update en.yml

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -585,7 +585,7 @@ en:
     language_codes: Language codes
     language_libretto: Language of libretto
     language_note: Language note
-    language_of_cataloging: Language of cataloging
+    language_of_cataloging: Cataloging language
     language_original_text: Language of original text
     language_text: Language of text
     later_entry: Later entry


### PR DESCRIPTION
We call this "Cataloging language" in the guidelines (https://guidelines.rism.info/cataloguing.html#cat_language and throughout) and it refers to what catalogers select in 040$b. The field should be named the same as this phrase.