### PR TITLE
Update en.yml

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -678,6 +678,7 @@ en:
     name_family: Name of family
     name_of_part: Name of part/section of a work
     name_printer: Name of printer
+    name_titles_words: Titles and words associated with a name
     name_variant: Name variant
     name_variants: Name variants
     named_dramatic_roles: Named dramatic role


### PR DESCRIPTION
Adding a new key: name_titles_words for "Titles and words associated with a name" for use in 100$c in People.

German: Mit einem Namen verbundene Titel und Zusätze

I put it alphabetically under "Name" to group it by names, rather than "Title" which is more in the sense of "book title."